### PR TITLE
Add basic test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ npm install
 npm start
 ```
 
+## Testing
+
+Run the automated test suite with:
+
+```bash
+npm test
+```
+
 ## How It Works
 
 1. Input topics or knowledge areas

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,0 +1,66 @@
+const request = require('supertest');
+
+let app;
+
+beforeAll(() => {
+  process.env.OPENAI_API_KEY = 'test';
+  process.env.ANTHROPIC_API_KEY = 'test';
+  process.env.GOOGLE_API_KEY = '';
+  process.env.NODE_ENV = 'test';
+  jest.resetModules();
+  app = require('../src/app');
+});
+
+describe('API Endpoints', () => {
+  test('GET /api/providers returns available providers', async () => {
+    const res = await request(app).get('/api/providers');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.providers).toEqual(['GPT-4', 'Claude']);
+  });
+
+  test('POST /api/generateFAQ returns combined answers', async () => {
+    const questions = [{ id: 1, topic: 'test', question: 'What is testing?' }];
+    const res = await request(app)
+      .post('/api/generateFAQ')
+      .send({ questions });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.faqs[0].answer).toContain('Réponse combinée:');
+  });
+
+  test('GET /api/exportFAQ returns JSONL after generation', async () => {
+    const questions = [{ id: 1, topic: 'test', question: 'Why?' }];
+    await request(app).post('/api/generateFAQ').send({ questions });
+    const res = await request(app).get('/api/exportFAQ');
+    expect(res.statusCode).toBe(200);
+    expect(res.text.trim()).toContain('"prompt"');
+    expect(res.header['content-type']).toMatch(/text\/plain/);
+  });
+
+  test('POST /api/generateQuestions missing topics returns 400', async () => {
+    const res = await request(app)
+      .post('/api/generateQuestions')
+      .send({});
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('POST /api/smartSort missing questions returns 400', async () => {
+    const res = await request(app)
+      .post('/api/smartSort')
+      .send({});
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('POST /api/generateTopicVariations missing topic returns 400', async () => {
+    const res = await request(app)
+      .post('/api/generateTopicVariations')
+      .send({});
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('POST /api/generateSmartTags missing text returns 400', async () => {
+    const res = await request(app)
+      .post('/api/generateSmartTags')
+      .send({});
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "start": "node src/app.js",
         "dev": "cross-env NODE_ENV=development nodemon src/app.js",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "test": "jest"
     },
     "dependencies": {
         "@anthropic-ai/sdk": "latest",
@@ -18,6 +18,8 @@
     },
     "devDependencies": {
         "cross-env": "7.0.3",
-        "nodemon": "3.0.2"
+        "nodemon": "3.0.2",
+        "jest": "^29.0.0",
+        "supertest": "^6.3.3"
     }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -508,12 +508,16 @@ app.get('*', (req, res) => {
     res.sendFile(path.join(__dirname, '../public/index.html'));
 });
 
-app.listen(port, () => {
-    console.log(`FAQ Generator app listening at http://localhost:${port}`);
-    devLog('Server started in development mode');
-    devLog('Environment:', {
-        NODE_ENV: process.env.NODE_ENV,
-        providers,
-        categories
+if (require.main === module) {
+    app.listen(port, () => {
+        console.log(`FAQ Generator app listening at http://localhost:${port}`);
+        devLog('Server started in development mode');
+        devLog('Environment:', {
+            NODE_ENV: process.env.NODE_ENV,
+            providers,
+            categories
+        });
     });
-});
+}
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- export the Express app for testing
- add Jest and Supertest setup
- implement integration tests for API endpoints
- document how to run tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684304c082d8832ba0090b6aa7bbe8ea